### PR TITLE
Add automated Google Play release workflow for Android TV

### DIFF
--- a/.github/workflows/publish-google-play.yml
+++ b/.github/workflows/publish-google-play.yml
@@ -1,0 +1,271 @@
+name: Publish Google Play
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Stable semantic version to package (for example 1.0.0)"
+        required: true
+        type: string
+      submit_to_store:
+        description: "Submit the signed app bundle to Google Play"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-google-play
+  cancel-in-progress: false
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_NOLOGO: true
+  AVALONIA_TELEMETRY_OPTOUT: true
+  PLAY_PACKAGE_NAME: ${{ vars.GOOGLE_PLAY_PACKAGE_NAME }}
+  PLAY_TRACK: ${{ vars.GOOGLE_PLAY_TRACK || 'internal' }}
+
+jobs:
+  package-and-publish:
+    name: Package, sign, and publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Resolve release version
+        id: version
+        shell: bash
+        env:
+          REQUESTED_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
+        run: |
+          version="${REQUESTED_VERSION#v}"
+
+          if [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            major=$((10#${BASH_REMATCH[1]}))
+            minor=$((10#${BASH_REMATCH[2]}))
+            patch=$((10#${BASH_REMATCH[3]}))
+
+            if (( major > 2099 || minor > 999 || patch > 999 )); then
+              echo "::error::Version '$version' cannot be represented as a Google Play version code. Major must be at most 2099; minor and patch must be at most 999."
+              exit 1
+            fi
+
+            # Google Play requires a positive, monotonically increasing integer.
+            # Mireya 0.2.0 becomes 2001 and Mireya 1.0.0 becomes 1000001.
+            version_code=$((major * 1000000 + minor * 1000 + patch + 1))
+            if (( version_code > 2100000000 )); then
+              echo "::error::Version code '$version_code' exceeds Google Play's limit."
+              exit 1
+            fi
+
+            echo "eligible=true" >> "$GITHUB_OUTPUT"
+            echo "version=$version" >> "$GITHUB_OUTPUT"
+            echo "version_code=$version_code" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)- ]]; then
+            echo "::notice::Google Play submission is skipped for pre-release version '$version'."
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "::error::Version '$version' is not a supported Semantic Version."
+          exit 1
+
+      - name: Validate package and signing configuration
+        if: steps.version.outputs.eligible == 'true'
+        shell: bash
+        env:
+          ANDROID_SIGNING_KEYSTORE_BASE64: ${{ secrets.ANDROID_SIGNING_KEYSTORE_BASE64 }}
+          ANDROID_SIGNING_KEY_ALIAS: ${{ secrets.ANDROID_SIGNING_KEY_ALIAS }}
+          ANDROID_SIGNING_KEY_PASSWORD: ${{ secrets.ANDROID_SIGNING_KEY_PASSWORD }}
+          ANDROID_SIGNING_STORE_PASSWORD: ${{ secrets.ANDROID_SIGNING_STORE_PASSWORD }}
+        run: |
+          if [[ -z "$PLAY_PACKAGE_NAME" ]]; then
+            echo "::error::Repository variable 'GOOGLE_PLAY_PACKAGE_NAME' is required."
+            exit 1
+          fi
+
+          if [[ "$PLAY_PACKAGE_NAME" != "dev.moritzreis.mireya" ]]; then
+            echo "::error::GOOGLE_PLAY_PACKAGE_NAME must match the Android project's ApplicationId 'dev.moritzreis.mireya'."
+            exit 1
+          fi
+
+          required_secrets=(
+            ANDROID_SIGNING_KEYSTORE_BASE64
+            ANDROID_SIGNING_KEY_ALIAS
+            ANDROID_SIGNING_KEY_PASSWORD
+            ANDROID_SIGNING_STORE_PASSWORD
+          )
+          for secret_name in "${required_secrets[@]}"; do
+            if [[ -z "${!secret_name}" ]]; then
+              echo "::error::Repository secret '$secret_name' is required."
+              exit 1
+            fi
+          done
+
+      - name: Validate Google Play publishing configuration
+        if: steps.version.outputs.eligible == 'true' && (github.event_name == 'push' || inputs.submit_to_store)
+        shell: bash
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [[ -z "$GOOGLE_PLAY_SERVICE_ACCOUNT_JSON" ]]; then
+            echo "::error::Repository secret 'GOOGLE_PLAY_SERVICE_ACCOUNT_JSON' is required for Store submission."
+            exit 1
+          fi
+          if [[ -z "$PLAY_TRACK" ]]; then
+            echo "::error::Repository variable 'GOOGLE_PLAY_TRACK' must not be empty when configured."
+            exit 1
+          fi
+
+      - name: Set up .NET
+        if: steps.version.outputs.eligible == 'true'
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+          cache: true
+          cache-dependency-path: |
+            **/packages.lock.json
+            **/*.csproj
+
+      - name: Set up Java
+        if: steps.version.outputs.eligible == 'true'
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Install .NET Android workload
+        if: steps.version.outputs.eligible == 'true'
+        run: dotnet workload install android
+
+      - name: Restore .NET tools and projects
+        if: steps.version.outputs.eligible == 'true'
+        shell: bash
+        run: |
+          dotnet tool restore
+          dotnet restore ./src/Mireya.Client.Android/Mireya.Client.Android.csproj --disable-parallel /m:1
+
+      - name: Restore and verify upload keystore
+        if: steps.version.outputs.eligible == 'true'
+        id: keystore
+        shell: bash
+        env:
+          ANDROID_SIGNING_KEYSTORE_BASE64: ${{ secrets.ANDROID_SIGNING_KEYSTORE_BASE64 }}
+          ANDROID_SIGNING_KEY_ALIAS: ${{ secrets.ANDROID_SIGNING_KEY_ALIAS }}
+          ANDROID_SIGNING_STORE_PASSWORD: ${{ secrets.ANDROID_SIGNING_STORE_PASSWORD }}
+        run: |
+          keystore_path="$RUNNER_TEMP/mireya-upload.keystore"
+          printf '%s' "$ANDROID_SIGNING_KEYSTORE_BASE64" | base64 --decode > "$keystore_path"
+          chmod 600 "$keystore_path"
+
+          keytool -list \
+            -keystore "$keystore_path" \
+            -storepass "$ANDROID_SIGNING_STORE_PASSWORD" \
+            -alias "$ANDROID_SIGNING_KEY_ALIAS" > /dev/null
+
+          echo "path=$keystore_path" >> "$GITHUB_OUTPUT"
+
+      - name: Build signed Android App Bundle
+        if: steps.version.outputs.eligible == 'true'
+        id: package
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          VERSION_CODE: ${{ steps.version.outputs.version_code }}
+          KEYSTORE_PATH: ${{ steps.keystore.outputs.path }}
+          ANDROID_SIGNING_KEY_ALIAS: ${{ secrets.ANDROID_SIGNING_KEY_ALIAS }}
+          ANDROID_SIGNING_KEY_PASSWORD: ${{ secrets.ANDROID_SIGNING_KEY_PASSWORD }}
+          ANDROID_SIGNING_STORE_PASSWORD: ${{ secrets.ANDROID_SIGNING_STORE_PASSWORD }}
+        run: |
+          project="./src/Mireya.Client.Android/Mireya.Client.Android.csproj"
+          artifact_directory="$GITHUB_WORKSPACE/artifacts/google-play"
+          artifact_path="$artifact_directory/mireya-android-$RELEASE_VERSION.aab"
+          mkdir -p "$artifact_directory"
+
+          dotnet publish "$project" \
+            --configuration Release \
+            --framework net10.0-android \
+            --no-restore \
+            --disable-build-servers \
+            -m:1 \
+            -p:BuildInParallel=false \
+            -p:SkipNSwag=true \
+            -p:RunAOTCompilation=false \
+            -p:AndroidPackageFormat=aab \
+            -p:AndroidPackageFormats=aab \
+            -p:AndroidKeyStore=false \
+            -p:ApplicationVersion="$VERSION_CODE" \
+            -p:ApplicationDisplayVersion="$RELEASE_VERSION" \
+            -p:Version="$RELEASE_VERSION"
+
+          mapfile -t bundles < <(
+            find ./src/Mireya.Client.Android/bin/Release/net10.0-android \
+              -type f -name "$PLAY_PACKAGE_NAME.aab" -print
+          )
+          if (( ${#bundles[@]} != 1 )); then
+            echo "::error::Expected exactly one unsigned AAB, found ${#bundles[@]}."
+            exit 1
+          fi
+
+          cp "${bundles[0]}" "$artifact_path"
+          jarsigner \
+            -sigalg SHA256withRSA \
+            -digestalg SHA-256 \
+            -keystore "$KEYSTORE_PATH" \
+            -storepass "$ANDROID_SIGNING_STORE_PASSWORD" \
+            -keypass "$ANDROID_SIGNING_KEY_PASSWORD" \
+            "$artifact_path" \
+            "$ANDROID_SIGNING_KEY_ALIAS"
+          jarsigner -verify "$artifact_path"
+
+          # Play accepts the ABI directory tree (arm64-v8a/*.so, x86_64/*.so)
+          # as a native debug-symbol archive. Extracting it from the final AAB
+          # guarantees that the symbols correspond exactly to the uploaded build.
+          symbols_stage="$(mktemp -d)"
+          symbols_path="$artifact_directory/mireya-android-$RELEASE_VERSION-native-debug-symbols.zip"
+          unzip -q "$artifact_path" 'base/lib/*/*.so' -d "$symbols_stage"
+          if ! find "$symbols_stage/base/lib" -type f -name '*.so' -print -quit | grep -q .; then
+            echo "::error::No native libraries were found in the completed AAB."
+            exit 1
+          fi
+          (
+            cd "$symbols_stage/base/lib"
+            zip -q -r "$symbols_path" . -i '*.so'
+          )
+
+          echo "aab_path=$artifact_path" >> "$GITHUB_OUTPUT"
+          echo "debug_symbols_path=$symbols_path" >> "$GITHUB_OUTPUT"
+
+      - name: Upload signed app bundle
+        if: always() && steps.version.outputs.eligible == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: mireya-google-play-${{ steps.version.outputs.version }}
+          path: |
+            artifacts/google-play/*.aab
+            artifacts/google-play/*-native-debug-symbols.zip
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Publish app bundle to Google Play
+        if: steps.version.outputs.eligible == 'true' && (github.event_name == 'push' || inputs.submit_to_store)
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: ${{ env.PLAY_PACKAGE_NAME }}
+          releaseFiles: ${{ steps.package.outputs.aab_path }}
+          debugSymbols: ${{ steps.package.outputs.debug_symbols_path }}
+          tracks: ${{ env.PLAY_TRACK }}
+          status: completed
+          releaseName: Mireya ${{ steps.version.outputs.version }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,3 +35,4 @@ Display clients connect to a Mireya backend, register themselves, wait for appro
 - [Operations](operations.md): configuration, Docker, Aspire, health checks, alerting, and runtime notes.
 - [API](api.md): endpoint groups, auth roles, SignalR hub behavior, and generated client workflow.
 - [Packaging](packaging.md): current client platform status and packaging notes.
+- [Google Play Release](google-play-release.md): Android signing, Play Console setup, and automated release publishing.

--- a/docs/_navbar.md
+++ b/docs/_navbar.md
@@ -5,4 +5,5 @@
 - [API](api.md)
 - [Packaging](packaging.md)
 - [Microsoft Store Release](microsoft-store-release.md)
+- [Google Play Release](google-play-release.md)
 - [Privacy](privacy.md)

--- a/docs/development.md
+++ b/docs/development.md
@@ -18,21 +18,21 @@ dotnet tool restore
 
 ## Project structure
 
-| Project | Purpose |
-| --- | --- |
-| `src/Mireya.Api` | ASP.NET Core API, Blazor Server admin UI, Identity, SignalR hub, OpenAPI, static uploads, and startup wiring. |
-| `src/Mireya.Application` | Business services for assets, campaigns, scheduling, screens, zones, audit, playback reporting, alerting, and synchronization. |
-| `src/Mireya.Database` | Shared EF Core models and `MireyaDbContext`. |
-| `src/Mireya.Database.Sqlite` | SQLite provider and migrations for local development. |
-| `src/Mireya.Database.Postgres` | PostgreSQL provider and migrations for Docker/production-like runs. |
-| `src/Mireya.ApiClient` | Generated NSwag API client plus client-side services, auth, SignalR, local SQLite store, backend management, and asset sync. |
-| `src/Mireya.ApiClient.TestConsole` | Small console harness for manual API-client checks. |
-| `src/Mireya.Client.Core` | Shared Avalonia display-client UI, view models, settings, converters, and platform abstractions. |
-| `src/Mireya.Client.Desktop` | Windows/Linux desktop head with WebView2 website rendering, LibVLC video rendering, and desktop credential storage. |
-| `src/Mireya.Client.Android` | Android TV head with native Android WebView, LibVLC, Leanback launcher metadata, and immersive fullscreen behavior. |
-| `src/Mireya.Application.Tests` | xUnit tests for application services using in-memory SQLite and NSubstitute. |
-| `src/MireyaDigitalSignage.AppHost` | .NET Aspire orchestration for the API plus PostgreSQL. |
-| `src/MireyaDigitalSignage.ServiceDefaults` | Shared Aspire service defaults, health endpoints, telemetry, resilience, and service discovery. |
+| Project                                    | Purpose                                                                                                                        |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| `src/Mireya.Api`                           | ASP.NET Core API, Blazor Server admin UI, Identity, SignalR hub, OpenAPI, static uploads, and startup wiring.                  |
+| `src/Mireya.Application`                   | Business services for assets, campaigns, scheduling, screens, zones, audit, playback reporting, alerting, and synchronization. |
+| `src/Mireya.Database`                      | Shared EF Core models and `MireyaDbContext`.                                                                                   |
+| `src/Mireya.Database.Sqlite`               | SQLite provider and migrations for local development.                                                                          |
+| `src/Mireya.Database.Postgres`             | PostgreSQL provider and migrations for Docker/production-like runs.                                                            |
+| `src/Mireya.ApiClient`                     | Generated NSwag API client plus client-side services, auth, SignalR, local SQLite store, backend management, and asset sync.   |
+| `src/Mireya.ApiClient.TestConsole`         | Small console harness for manual API-client checks.                                                                            |
+| `src/Mireya.Client.Core`                   | Shared Avalonia display-client UI, view models, settings, converters, and platform abstractions.                               |
+| `src/Mireya.Client.Desktop`                | Windows/Linux desktop head with WebView2 website rendering, LibVLC video rendering, and desktop credential storage.            |
+| `src/Mireya.Client.Android`                | Android TV head with native Android WebView, LibVLC, Leanback launcher metadata, and immersive fullscreen behavior.            |
+| `src/Mireya.Application.Tests`             | xUnit tests for application services using in-memory SQLite and NSubstitute.                                                   |
+| `src/MireyaDigitalSignage.AppHost`         | .NET Aspire orchestration for the API plus PostgreSQL.                                                                         |
+| `src/MireyaDigitalSignage.ServiceDefaults` | Shared Aspire service defaults, health endpoints, telemetry, resilience, and service discovery.                                |
 
 ## Run locally
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -226,8 +226,8 @@ Build and install a standalone Debug APK with embedded assemblies:
 
 ```bash
 dotnet build src/Mireya.Client.Android/Mireya.Client.Android.csproj -p:EmbedAssembliesIntoApk=true -p:AndroidFastDeploymentType=None
-adb install -r src/Mireya.Client.Android/bin/Debug/net10.0-android/com.mireya.signage.tv-Signed.apk
-adb shell monkey -p com.mireya.signage.tv -c android.intent.category.LAUNCHER 1
+adb install -r src/Mireya.Client.Android/bin/Debug/net10.0-android/dev.moritzreis.mireya-Signed.apk
+adb shell monkey -p dev.moritzreis.mireya -c android.intent.category.LAUNCHER 1
 ```
 
 Alternatively, let MSBuild deploy to the selected device:
@@ -239,7 +239,7 @@ dotnet build src/Mireya.Client.Android/Mireya.Client.Android.csproj -t:Run
 Useful diagnostics:
 
 ```bash
-adb logcat --pid=$(adb shell pidof com.mireya.signage.tv)
+adb logcat --pid=$(adb shell pidof dev.moritzreis.mireya)
 adb exec-out screencap -p > screen.png
 ```
 

--- a/docs/google-play-release.md
+++ b/docs/google-play-release.md
@@ -8,10 +8,10 @@ Create the app in Google Play Console with package name `dev.moritzreis.mireya`,
 
 Set these GitHub repository variables under **Settings > Secrets and variables > Actions > Variables**:
 
-| Repository variable | Required | Value |
-| --- | --- | --- |
-| `GOOGLE_PLAY_PACKAGE_NAME` | Yes | `dev.moritzreis.mireya` |
-| `GOOGLE_PLAY_TRACK` | No | Play release track; defaults to `internal`. Use `alpha`, `beta`, `production`, or a custom track name only after that track is configured in Play Console. |
+| Repository variable        | Required | Value                                                                                                                                                      |
+| -------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GOOGLE_PLAY_PACKAGE_NAME` | Yes      | `dev.moritzreis.mireya`                                                                                                                                    |
+| `GOOGLE_PLAY_TRACK`        | No       | Play release track; defaults to `internal`. Use `alpha`, `beta`, `production`, or a custom track name only after that track is configured in Play Console. |
 
 ### Create the upload key
 
@@ -36,12 +36,12 @@ Encode the complete keystore file as a single Base64 value. In PowerShell:
 
 Add these GitHub repository secrets:
 
-| Repository secret | Required for | Value |
-| --- | --- | --- |
-| `ANDROID_SIGNING_KEYSTORE_BASE64` | Every build | Base64-encoded contents of `mireya-upload.jks` |
-| `ANDROID_SIGNING_KEY_ALIAS` | Every build | Upload-key alias, for example `mireya-upload` |
-| `ANDROID_SIGNING_KEY_PASSWORD` | Every build | Password for the key alias |
-| `ANDROID_SIGNING_STORE_PASSWORD` | Every build | Password for the keystore |
+| Repository secret                  | Required for          | Value                                                           |
+| ---------------------------------- | --------------------- | --------------------------------------------------------------- |
+| `ANDROID_SIGNING_KEYSTORE_BASE64`  | Every build           | Base64-encoded contents of `mireya-upload.jks`                  |
+| `ANDROID_SIGNING_KEY_ALIAS`        | Every build           | Upload-key alias, for example `mireya-upload`                   |
+| `ANDROID_SIGNING_KEY_PASSWORD`     | Every build           | Password for the key alias                                      |
+| `ANDROID_SIGNING_STORE_PASSWORD`   | Every build           | Password for the keystore                                       |
 | `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | Store submission only | Entire JSON key downloaded for the Google Cloud service account |
 
 Do not use the debug keystore. Once the first artifact is uploaded, future updates must use the same upload key unless the key is reset through Play Console.

--- a/docs/google-play-release.md
+++ b/docs/google-play-release.md
@@ -1,0 +1,88 @@
+# Google Play Release
+
+Stable Mireya tags are built as signed Android App Bundles and submitted to Google Play by `.github/workflows/publish-google-play.yml`. Pre-release tags continue through other release workflows but are intentionally not packaged or submitted to Play.
+
+## One-time Google Play setup
+
+Create the app in Google Play Console with package name `dev.moritzreis.mireya`, opt in to Play App Signing, complete the required app-content and store-listing forms, and manually upload the first signed AAB. The Google Play publishing API cannot create the app or perform its first upload.
+
+Set these GitHub repository variables under **Settings > Secrets and variables > Actions > Variables**:
+
+| Repository variable | Required | Value |
+| --- | --- | --- |
+| `GOOGLE_PLAY_PACKAGE_NAME` | Yes | `dev.moritzreis.mireya` |
+| `GOOGLE_PLAY_TRACK` | No | Play release track; defaults to `internal`. Use `alpha`, `beta`, `production`, or a custom track name only after that track is configured in Play Console. |
+
+### Create the upload key
+
+The workflow signs every release with your Play upload key. Create it once and retain both the keystore and its credentials in a secure backup:
+
+```bash
+keytool -genkeypair -v \
+  -keystore mireya-upload.jks \
+  -alias mireya-upload \
+  -keyalg RSA \
+  -keysize 4096 \
+  -validity 10000
+```
+
+Encode the complete keystore file as a single Base64 value. In PowerShell:
+
+```powershell
+[Convert]::ToBase64String(
+  [IO.File]::ReadAllBytes("mireya-upload.jks")
+) | Set-Clipboard
+```
+
+Add these GitHub repository secrets:
+
+| Repository secret | Required for | Value |
+| --- | --- | --- |
+| `ANDROID_SIGNING_KEYSTORE_BASE64` | Every build | Base64-encoded contents of `mireya-upload.jks` |
+| `ANDROID_SIGNING_KEY_ALIAS` | Every build | Upload-key alias, for example `mireya-upload` |
+| `ANDROID_SIGNING_KEY_PASSWORD` | Every build | Password for the key alias |
+| `ANDROID_SIGNING_STORE_PASSWORD` | Every build | Password for the keystore |
+| `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | Store submission only | Entire JSON key downloaded for the Google Cloud service account |
+
+Do not use the debug keystore. Once the first artifact is uploaded, future updates must use the same upload key unless the key is reset through Play Console.
+
+### Configure publishing API access
+
+1. Enable the **Google Play Android Developer API** in a Google Cloud project.
+2. Create a dedicated service account and a JSON key.
+3. In Google Play Console, open **Users and permissions**, invite the service-account email, grant it access only to the Mireya app, and allow it to create and publish releases to the selected track.
+4. Store the entire downloaded JSON document in `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`.
+
+The service account does not need broad Google Cloud project roles. Its Play Console app permissions control what the workflow can publish.
+
+## Release behavior
+
+A stable tag such as `v0.2.0` starts the Google Play workflow independently of the Docker and Microsoft Store workflows. It:
+
+1. Validates the stable semantic version, package name, and signing configuration.
+2. Installs the .NET 10 Android workload and restores the projects.
+3. Restores and verifies the upload keystore.
+4. Builds and signs an Android App Bundle (`.aab`) for `net10.0-android`.
+5. Extracts the bundle's native libraries into the ABI layout required by Play and creates a matching `native-debug-symbols.zip`.
+6. Uploads the signed bundle and native-symbol archive as GitHub Actions artifacts retained for 30 days.
+7. Publishes the bundle and available native symbols to `GOOGLE_PLAY_TRACK`, or to the `internal` track when that variable is unset.
+
+Google Play requires a positive, monotonically increasing integer `versionCode`. Mireya maps `major.minor.patch` to `major * 1,000,000 + minor * 1,000 + patch + 1`; for example, `0.2.0` becomes `2001` and `1.0.0` becomes `1000001`. Major versions are therefore limited to 2099 and minor/patch components to 999.
+
+Run **Publish Google Play** manually with `submit_to_store` disabled to build and retain a signed AAB without changing Play Console. Enable `submit_to_store` to publish the manual build. Stable tag pushes publish automatically; pre-release versions such as `1.0.0-rc.1` are skipped.
+
+For the safest rollout, keep `GOOGLE_PLAY_TRACK` set to `internal` until the internal-testing release has been installed and exercised on real Android TV hardware. Promote a verified release in Play Console, or deliberately change the configured track for subsequent releases.
+
+## Play Console diagnostic warnings
+
+Play can show a warning that no deobfuscation file is associated with the bundle. Mireya does not currently run the R8/ProGuard Java code shrinker, so there is no `mapping.txt` to upload and this warning is not actionable. Do not enable R8 only to hide the warning; if R8 is enabled later, preserve the build's generated mapping file because it must match that exact release.
+
+Play also detects the native `.so` libraries supplied by .NET, SkiaSharp, LibVLC, and SQLite. The workflow uploads `mireya-android-<version>-native-debug-symbols.zip` with automated submissions. For a manual AAB submission, upload the matching ZIP from the workflow artifact alongside that release. Some third-party NuGet libraries are already stripped by their publishers, so their private function names and source lines cannot be reconstructed locally; the archive still supplies every symbol present in the exact released binaries.
+
+## Before the first submitted release
+
+- Confirm that the Play Console app package is exactly `dev.moritzreis.mireya`.
+- Complete the TV app listing, privacy policy, data-safety declaration, content rating, target-audience declaration, and all other required Play forms.
+- Upload a TV banner and screenshots captured without real credentials or customer content.
+- Verify backend selection, registration and approval, asset synchronization, image/video/website playback, offline cache behavior, and remote commands on a supported 64-bit Android TV device.
+- Keep an offline backup of the upload keystore and both passwords.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -8,7 +8,7 @@ The Mireya display client uses a shared Avalonia core with platform-specific hea
 | `Mireya.Client.Desktop` | Implemented | Windows/Linux desktop head with WebView2 website rendering, LibVLC video rendering, and desktop credential storage. |
 | `Mireya.Client.Android` | Implemented | Android TV head with native Android WebView, LibVLC, Leanback launcher metadata, and immersive fullscreen behavior. |
 
-The Windows desktop head has repeatable Microsoft Store MSIX packaging. Other installers and store artifacts remain roadmap work.
+The Windows desktop head has repeatable Microsoft Store MSIX packaging, and the Android TV head has a signed Google Play App Bundle release workflow. Other installers remain roadmap work.
 
 ## Desktop
 
@@ -55,7 +55,7 @@ For Raspberry Pi-style targets, use a Linux ARM runtime such as `linux-arm64` af
 
 ## Android TV
 
-The Android TV head is implemented in `src/Mireya.Client.Android` and targets `net10.0-android` with application id `com.mireya.signage.tv`.
+The Android TV head is implemented in `src/Mireya.Client.Android` and targets `net10.0-android` with application id `dev.moritzreis.mireya`.
 
 It provides:
 
@@ -84,6 +84,8 @@ On Windows, Android SDK tools commonly live under `%LOCALAPPDATA%\Android\Sdk`.
 dotnet build src/Mireya.Client.Android/Mireya.Client.Android.csproj
 ```
 
+Stable releases are built, signed, retained as GitHub Actions artifacts, and optionally submitted to Google Play. See [Google Play Release](google-play-release.md) for the required repository variables and secrets, upload-key handling, Play API setup, and release behavior.
+
 ### Run on emulator or device
 
 Start the API and the emulator/device first. From the Android emulator, the host machine is reachable at `http://10.0.2.2:5000`; `localhost` points to the emulator itself.
@@ -92,8 +94,8 @@ Build a standalone APK with assemblies embedded and install it manually:
 
 ```bash
 dotnet build src/Mireya.Client.Android/Mireya.Client.Android.csproj -p:EmbedAssembliesIntoApk=true -p:AndroidFastDeploymentType=None
-adb install -r src/Mireya.Client.Android/bin/Debug/net10.0-android/com.mireya.signage.tv-Signed.apk
-adb shell monkey -p com.mireya.signage.tv -c android.intent.category.LAUNCHER 1
+adb install -r src/Mireya.Client.Android/bin/Debug/net10.0-android/dev.moritzreis.mireya-Signed.apk
+adb shell monkey -p dev.moritzreis.mireya -c android.intent.category.LAUNCHER 1
 ```
 
 The embedded-assemblies path avoids a common manual-install crash where a plain Debug APK expects Fast Deployment assemblies to have been pushed separately by the IDE.
@@ -107,7 +109,7 @@ dotnet build src/Mireya.Client.Android/Mireya.Client.Android.csproj -t:Run
 Useful diagnostics:
 
 ```bash
-adb logcat --pid=$(adb shell pidof com.mireya.signage.tv)
+adb logcat --pid=$(adb shell pidof dev.moritzreis.mireya)
 adb exec-out screencap -p > screen.png
 ```
 
@@ -127,4 +129,3 @@ Use the current desktop and Android heads as the pattern:
 - Additional Windows installer formats and MSIX architectures.
 - Linux kiosk packaging with a Linux-native website renderer.
 - Raspberry Pi packaging and service setup.
-- Android release signing and APK/AAB distribution workflow.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -2,9 +2,9 @@
 
 The Mireya display client uses a shared Avalonia core with platform-specific heads. The shared core owns the signage shell, backend-selection UI, playback view models, settings, and renderer interfaces. Each platform head provides its own composition root and concrete website/video renderers.
 
-| Project | Status | Role |
-| --- | --- | --- |
-| `Mireya.Client.Core` | Implemented | Shared Avalonia UI, view models, converters, settings, and platform abstractions. |
+| Project                 | Status      | Role                                                                                                                |
+| ----------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------- |
+| `Mireya.Client.Core`    | Implemented | Shared Avalonia UI, view models, converters, settings, and platform abstractions.                                   |
 | `Mireya.Client.Desktop` | Implemented | Windows/Linux desktop head with WebView2 website rendering, LibVLC video rendering, and desktop credential storage. |
 | `Mireya.Client.Android` | Implemented | Android TV head with native Android WebView, LibVLC, Leanback launcher metadata, and immersive fullscreen behavior. |
 

--- a/src/Mireya.ApiClient/Mireya.ApiClient.csproj
+++ b/src/Mireya.ApiClient/Mireya.ApiClient.csproj
@@ -19,6 +19,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />
     <PackageReference Include="Nanoid" Version="3.1.0" />
+    <!-- Override EF Core's vulnerable SQLitePCLRaw 2.1.11 native bundle. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.10" />
   </ItemGroup>
 
@@ -30,6 +32,7 @@
   <Target
     Name="NSwag"
     BeforeTargets="CoreCompile"
+    Condition="'$(SkipNSwag)' != 'true'"
     Inputs="nswag.json;../Mireya.Api/Mireya.Api.csproj"
     Outputs="Generated/MireyaApiClient.cs"
   >

--- a/src/Mireya.Client.Android/Mireya.Client.Android.csproj
+++ b/src/Mireya.Client.Android/Mireya.Client.Android.csproj
@@ -7,7 +7,7 @@
     <!-- Keep the historical root namespace so shared code and XAML need no churn. -->
     <RootNamespace>Mireya.Client.Avalonia</RootNamespace>
     <AssemblyName>Mireya.Client.Android</AssemblyName>
-    <ApplicationId>com.mireya.signage.tv</ApplicationId>
+    <ApplicationId>dev.moritzreis.mireya</ApplicationId>
     <ApplicationVersion>1</ApplicationVersion>
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
@@ -24,7 +24,10 @@
   <ItemGroup>
     <PackageReference Include="Avalonia.Android" Version="12.1.0" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="12.1.0" />
-    <PackageReference Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.2.0.3" />
+    <!-- Keep this aligned with the AndroidX family pulled by Avalonia.Android.
+         1.2.0.3 mixes Core 1.19 with Avalonia's Core.Ktx 1.17 and causes
+         duplicate Java classes during D8 packaging. -->
+    <PackageReference Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.2.0.2" />
     <!-- LibVLCSharp core ships the native Android VideoView; VideoLAN.LibVLC.Android
          supplies the libvlc .so binaries bundled into the APK. The Avalonia VideoView
          package is desktop-only (net8.0/netstandard2.0) so it is intentionally not used. -->


### PR DESCRIPTION
## Summary

- Add a GitHub Actions workflow to validate versions and configuration, build/sign Android App Bundles, upload artifacts, and optionally publish to Google Play.
- Document Google Play setup, signing keys, service-account permissions, release behavior, and diagnostic guidance.
- Update Android package identifiers and development/packaging documentation.
- Align AndroidX splash-screen dependencies and add the SQLitePCLRaw security override.
- Make NSwag generation skippable for release packaging.

## Testing

- Not run (not requested)