### PR TITLE
fix: the memory leak behind issue #53

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -35,6 +35,7 @@ jobs:
           dotnet restore ./src/Mireya.Client.Desktop/Mireya.Client.Desktop.csproj
           dotnet restore ./src/Mireya.ApiClient/Mireya.ApiClient.csproj
           dotnet restore ./src/Mireya.Application.Tests/Mireya.Application.Tests.csproj
+          dotnet restore ./src/Mireya.Client.Core.Tests/Mireya.Client.Core.Tests.csproj
 
       - name: Build backend API
         run: dotnet build ./src/Mireya.Api/Mireya.Api.csproj --configuration Release --no-restore
@@ -47,6 +48,9 @@ jobs:
 
       - name: Run tests
         run: dotnet test ./src/Mireya.Application.Tests/Mireya.Application.Tests.csproj --configuration Release --logger "trx;LogFileName=test-results.trx" --results-directory ./TestResults
+
+      - name: Run client tests
+        run: dotnet test ./src/Mireya.Client.Core.Tests/Mireya.Client.Core.Tests.csproj --configuration Release --logger "trx;LogFileName=client-test-results.trx" --results-directory ./TestResults
 
       - name: Upload test results
         if: always()

--- a/MireyaDigitalSignage.slnx
+++ b/MireyaDigitalSignage.slnx
@@ -11,6 +11,7 @@
     <Project Path="src/Mireya.ApiClient.TestConsole/Mireya.ApiClient.TestConsole.csproj" />
     <Project Path="src/Mireya.ApiClient/Mireya.ApiClient.csproj" />
     <Project Path="src/Mireya.Client.Core/Mireya.Client.Core.csproj" />
+    <Project Path="src/Mireya.Client.Core.Tests/Mireya.Client.Core.Tests.csproj" />
     <Project Path="src/Mireya.Client.Desktop/Mireya.Client.Desktop.csproj" />
     <Project Path="src/Mireya.Client.Android/Mireya.Client.Android.csproj" />
   </Folder>

--- a/docs/development.md
+++ b/docs/development.md
@@ -29,7 +29,7 @@ dotnet tool restore
 | `src/Mireya.ApiClient.TestConsole`         | Small console harness for manual API-client checks.                                                                            |
 | `src/Mireya.Client.Core`                   | Shared Avalonia display-client UI, view models, settings, converters, and platform abstractions.                               |
 | `src/Mireya.Client.Desktop`                | Windows/Linux desktop head with WebView2 website rendering, LibVLC video rendering, and desktop credential storage.            |
-| `src/Mireya.Client.Android`                | Android TV head with native Android WebView, Media3/ExoPlayer, Leanback launcher metadata, and immersive fullscreen behavior.   |
+| `src/Mireya.Client.Android`                | Android TV head with native Android WebView, Media3/ExoPlayer, Leanback launcher metadata, and immersive fullscreen behavior.  |
 | `src/Mireya.Application.Tests`             | xUnit tests for application services using in-memory SQLite and NSubstitute.                                                   |
 | `src/Mireya.Client.Core.Tests`             | xUnit tests for the display-client view models, running on the headless Avalonia platform.                                     |
 | `src/MireyaDigitalSignage.AppHost`         | .NET Aspire orchestration for the API plus PostgreSQL.                                                                         |

--- a/docs/development.md
+++ b/docs/development.md
@@ -31,6 +31,7 @@ dotnet tool restore
 | `src/Mireya.Client.Desktop`                | Windows/Linux desktop head with WebView2 website rendering, LibVLC video rendering, and desktop credential storage.            |
 | `src/Mireya.Client.Android`                | Android TV head with native Android WebView, Media3/ExoPlayer, Leanback launcher metadata, and immersive fullscreen behavior.   |
 | `src/Mireya.Application.Tests`             | xUnit tests for application services using in-memory SQLite and NSubstitute.                                                   |
+| `src/Mireya.Client.Core.Tests`             | xUnit tests for the display-client view models, running on the headless Avalonia platform.                                     |
 | `src/MireyaDigitalSignage.AppHost`         | .NET Aspire orchestration for the API plus PostgreSQL.                                                                         |
 | `src/MireyaDigitalSignage.ServiceDefaults` | Shared Aspire service defaults, health endpoints, telemetry, resilience, and service discovery.                                |
 
@@ -156,9 +157,12 @@ dotnet build src/Mireya.Client.Desktop/Mireya.Client.Desktop.csproj -c Release
 
 # Application tests
 dotnet test src/Mireya.Application.Tests/Mireya.Application.Tests.csproj -c Release
+
+# Display-client tests
+dotnet test src/Mireya.Client.Core.Tests/Mireya.Client.Core.Tests.csproj -c Release
 ```
 
-The PR workflow restores local tools, restores/builds the API, API client, desktop client, and runs `Mireya.Application.Tests`.
+The PR workflow restores local tools, restores/builds the API, API client, desktop client, and runs `Mireya.Application.Tests` and `Mireya.Client.Core.Tests`.
 
 ## API client generation
 

--- a/src/Mireya.Client.Core.Tests/HeadlessSessionFixture.cs
+++ b/src/Mireya.Client.Core.Tests/HeadlessSessionFixture.cs
@@ -1,0 +1,29 @@
+using Avalonia.Headless;
+
+namespace Mireya.Client.Core.Tests;
+
+/// <summary>
+///     Shares a single headless Avalonia session between the tests of a class. Avalonia can
+///     only be initialized once per process and owns its own UI thread, so test bodies that
+///     touch Avalonia types have to be dispatched onto that thread.
+/// </summary>
+public sealed class HeadlessSessionFixture : IDisposable
+{
+    private readonly HeadlessUnitTestSession _session = HeadlessUnitTestSession.StartNew(
+        typeof(TestAppBuilder)
+    );
+
+    /// <summary>Runs the test body on the Avalonia UI thread of the headless session.</summary>
+    public Task RunAsync(Action testBody)
+    {
+        Func<Task> dispatched = () =>
+        {
+            testBody();
+            return Task.CompletedTask;
+        };
+
+        return _session.Dispatch(dispatched, CancellationToken.None);
+    }
+
+    public void Dispose() => _session.Dispose();
+}

--- a/src/Mireya.Client.Core.Tests/Mireya.Client.Core.Tests.csproj
+++ b/src/Mireya.Client.Core.Tests/Mireya.Client.Core.Tests.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Headless" Version="12.1.1" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="NSubstitute" Version="6.2.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Mireya.Client.Core\Mireya.Client.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Mireya.Client.Core.Tests/TestAppBuilder.cs
+++ b/src/Mireya.Client.Core.Tests/TestAppBuilder.cs
@@ -1,0 +1,16 @@
+using Avalonia;
+using Avalonia.Headless;
+
+namespace Mireya.Client.Core.Tests;
+
+/// <summary>
+///     Entry point for the headless Avalonia application used by the tests. The view models
+///     rely on <see cref="Avalonia.Threading.Dispatcher" /> and on Avalonia's bitmap loading,
+///     both of which need an initialized platform. The headless drawing backend keeps the
+///     tests free of native graphics dependencies so they also run on CI.
+/// </summary>
+public static class TestAppBuilder
+{
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<Application>().UseHeadless(new AvaloniaHeadlessPlatformOptions());
+}

--- a/src/Mireya.Client.Core.Tests/ViewModels/ContentDisplayViewModelImageLifetimeTests.cs
+++ b/src/Mireya.Client.Core.Tests/ViewModels/ContentDisplayViewModelImageLifetimeTests.cs
@@ -31,6 +31,39 @@ public sealed class ContentDisplayViewModelImageLifetimeTests
         _session = session;
     }
 
+    public static TheoryData<string, PlaylistItem, string> TransitionsThatMustReleaseTheImage() =>
+        new()
+        {
+            {
+                "ShowVideo",
+                new PlaylistItem { AssetType = AssetType.Video },
+                "The image left behind by an image to video transition was not disposed."
+            },
+            {
+                "ShowWebsite",
+                new PlaylistItem
+                {
+                    AssetType = AssetType.Website,
+                    Source = "https://example.com/",
+                    DurationSeconds = 10,
+                },
+                "The image left behind by an image to website transition was not disposed."
+            },
+            {
+                "ShowImage",
+                new PlaylistItem
+                {
+                    AssetType = AssetType.Image,
+                    LocalPath = Path.Combine(
+                        Path.GetTempPath(),
+                        $"mireya-missing-{Guid.NewGuid():N}.png"
+                    ),
+                    DurationSeconds = 10,
+                },
+                "The image was not disposed after a failed image load."
+            },
+        };
+
     [Fact]
     public Task DisposedBitmapIsRecognisedAsDisposed() =>
         _session.RunAsync(() =>
@@ -46,62 +79,16 @@ public sealed class ContentDisplayViewModelImageLifetimeTests
             Assert.True(IsDisposed(bitmap));
         });
 
-    [Fact]
-    public Task ShowVideoDisposesTheImageItReplaces() =>
+    [Theory]
+    [MemberData(nameof(TransitionsThatMustReleaseTheImage))]
+    public Task TransitionAwayFromAnImageDisposesIt(
+        string method,
+        PlaylistItem item,
+        string because
+    ) =>
         _session.RunAsync(() =>
-        {
-            var viewModel = CreateViewModel();
-            var image = CreateBitmap();
-            viewModel.CurrentImage = image;
-
-            Invoke(viewModel, "ShowVideo", new PlaylistItem { AssetType = AssetType.Video });
-
-            try
-            {
-                Assert.Null(viewModel.CurrentImage);
-                Assert.True(
-                    IsDisposed(image),
-                    "The image left behind by an image to video transition was not disposed."
-                );
-            }
-            finally
-            {
-                viewModel.Dispose();
-            }
-        });
-
-    [Fact]
-    public Task ShowWebsiteDisposesTheImageItReplaces() =>
-        _session.RunAsync(() =>
-        {
-            var viewModel = CreateViewModel();
-            var image = CreateBitmap();
-            viewModel.CurrentImage = image;
-
-            Invoke(
-                viewModel,
-                "ShowWebsite",
-                new PlaylistItem
-                {
-                    AssetType = AssetType.Website,
-                    Source = "https://example.com/",
-                    DurationSeconds = 10,
-                }
-            );
-
-            try
-            {
-                Assert.Null(viewModel.CurrentImage);
-                Assert.True(
-                    IsDisposed(image),
-                    "The image left behind by an image to website transition was not disposed."
-                );
-            }
-            finally
-            {
-                viewModel.Dispose();
-            }
-        });
+            AssertImageReleasedAfter(viewModel => InvokePrivate(viewModel, method, item), because)
+        );
 
     [Fact]
     public Task ShowImageDisposesThePreviousImageAndKeepsTheNewOne() =>
@@ -114,7 +101,7 @@ public sealed class ContentDisplayViewModelImageLifetimeTests
 
             try
             {
-                Invoke(
+                InvokePrivate(
                     viewModel,
                     "ShowImage",
                     new PlaylistItem
@@ -138,54 +125,13 @@ public sealed class ContentDisplayViewModelImageLifetimeTests
         });
 
     [Fact]
-    public Task ShowImageDisposesTheCurrentImageWhenTheFileIsMissing() =>
-        _session.RunAsync(() =>
-        {
-            var viewModel = CreateViewModel();
-            var image = CreateBitmap();
-            viewModel.CurrentImage = image;
-
-            Invoke(
-                viewModel,
-                "ShowImage",
-                new PlaylistItem
-                {
-                    AssetType = AssetType.Image,
-                    LocalPath = Path.Combine(
-                        Path.GetTempPath(),
-                        $"mireya-missing-{Guid.NewGuid():N}.png"
-                    ),
-                    DurationSeconds = 10,
-                }
-            );
-
-            try
-            {
-                Assert.Null(viewModel.CurrentImage);
-                Assert.True(
-                    IsDisposed(image),
-                    "The image was not disposed after a failed image load."
-                );
-            }
-            finally
-            {
-                viewModel.Dispose();
-            }
-        });
-
-    [Fact]
     public Task CleanupDisposesTheCurrentImage() =>
         _session.RunAsync(() =>
-        {
-            var viewModel = CreateViewModel();
-            var image = CreateBitmap();
-            viewModel.CurrentImage = image;
-
-            viewModel.Cleanup();
-
-            Assert.Null(viewModel.CurrentImage);
-            Assert.True(IsDisposed(image), "The image was not disposed during cleanup.");
-        });
+            AssertImageReleasedAfter(
+                viewModel => viewModel.Cleanup(),
+                "The image was not disposed during cleanup."
+            )
+        );
 
     [Fact]
     public Task ReassigningTheSameImageDoesNotDisposeIt() =>
@@ -197,7 +143,7 @@ public sealed class ContentDisplayViewModelImageLifetimeTests
 
             try
             {
-                InvokeSetCurrentImage(viewModel, image);
+                InvokePrivate(viewModel, "SetCurrentImage", image);
 
                 Assert.Same(image, viewModel.CurrentImage);
                 Assert.False(
@@ -214,6 +160,27 @@ public sealed class ContentDisplayViewModelImageLifetimeTests
     // ──────────────────────────────────────────────────────────────
     // Helpers
     // ──────────────────────────────────────────────────────────────
+
+    private static void AssertImageReleasedAfter(
+        Action<ContentDisplayViewModel> act,
+        string because
+    )
+    {
+        var viewModel = CreateViewModel();
+        var image = CreateBitmap();
+        viewModel.CurrentImage = image;
+
+        try
+        {
+            act(viewModel);
+            Assert.Null(viewModel.CurrentImage);
+            Assert.True(IsDisposed(image), because);
+        }
+        finally
+        {
+            viewModel.Dispose();
+        }
+    }
 
     private static ContentDisplayViewModel CreateViewModel()
     {
@@ -262,28 +229,24 @@ public sealed class ContentDisplayViewModelImageLifetimeTests
         }
     }
 
-    private static void Invoke(ContentDisplayViewModel viewModel, string method, PlaylistItem item)
+    private static void InvokePrivate(
+        ContentDisplayViewModel viewModel,
+        string method,
+        params object?[] arguments
+    )
     {
         var target =
             typeof(ContentDisplayViewModel).GetMethod(
                 method,
-                BindingFlags.Instance | BindingFlags.NonPublic
+                BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic
             ) ?? throw new InvalidOperationException($"{method} was not found on the view model.");
 
-        target.Invoke(viewModel, [item]);
-    }
+        if (target.IsStatic)
+        {
+            target.Invoke(null, [viewModel, .. arguments]);
+            return;
+        }
 
-    private static void InvokeSetCurrentImage(ContentDisplayViewModel viewModel, Bitmap? image)
-    {
-        var target =
-            typeof(ContentDisplayViewModel).GetMethod(
-                "SetCurrentImage",
-                BindingFlags.Instance | BindingFlags.NonPublic
-            )
-            ?? throw new InvalidOperationException(
-                "SetCurrentImage was not found on the view model."
-            );
-
-        target.Invoke(viewModel, [image]);
+        target.Invoke(viewModel, arguments);
     }
 }

--- a/src/Mireya.Client.Core.Tests/ViewModels/ContentDisplayViewModelImageLifetimeTests.cs
+++ b/src/Mireya.Client.Core.Tests/ViewModels/ContentDisplayViewModelImageLifetimeTests.cs
@@ -24,6 +24,11 @@ public sealed class ContentDisplayViewModelImageLifetimeTests
     private const string OnePixelPngBase64 =
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFAAH/q842iQAAAABJRU5ErkJggg==";
 
+    // Valid 2048x2 PNG. Its small encoded size keeps the test fixture lightweight while its
+    // width still crosses the production decode limit.
+    private const string OversizedLandscapePngBase64 =
+        "iVBORw0KGgoAAAANSUhEUgAACAAAAAACCAYAAADMgDxcAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAnSURBVHhe7cExAQAAAMKg9U9tDB+gAAAAAAAAAAAAAAAAAAAAgL8BQAIAAa/d9EwAAAAASUVORK5CYII=";
+
     private readonly HeadlessSessionFixture _session;
 
     public ContentDisplayViewModelImageLifetimeTests(HeadlessSessionFixture session)
@@ -125,6 +130,68 @@ public sealed class ContentDisplayViewModelImageLifetimeTests
         });
 
     [Fact]
+    public Task ShowImageBoundsTheDecodedPixelSize() =>
+        _session.RunAsync(() =>
+        {
+            var viewModel = CreateViewModel();
+            var path = WriteTempImage(OversizedLandscapePngBase64);
+
+            try
+            {
+                InvokePrivate(
+                    viewModel,
+                    "ShowImage",
+                    new PlaylistItem
+                    {
+                        AssetType = AssetType.Image,
+                        LocalPath = path,
+                        DurationSeconds = 10,
+                    }
+                );
+
+                Assert.NotNull(viewModel.CurrentImage);
+                Assert.Equal(1920, viewModel.CurrentImage!.PixelSize.Width);
+            }
+            finally
+            {
+                viewModel.Dispose();
+                File.Delete(path);
+            }
+        });
+
+    [Fact]
+    public Task ShowingTheSameAssetAgainReusesTheDecodedBitmap() =>
+        _session.RunAsync(() =>
+        {
+            var viewModel = CreateViewModel();
+            var path = WriteTempImage();
+            var item = new PlaylistItem
+            {
+                AssetId = Guid.NewGuid(),
+                AssetType = AssetType.Image,
+                LocalPath = path,
+                DurationSeconds = 10,
+            };
+
+            try
+            {
+                InvokePrivate(viewModel, "ShowImage", item);
+                var firstDecode = viewModel.CurrentImage;
+
+                InvokePrivate(viewModel, "ShowImage", item);
+
+                Assert.NotNull(firstDecode);
+                Assert.Same(firstDecode, viewModel.CurrentImage);
+                Assert.False(IsDisposed(firstDecode!));
+            }
+            finally
+            {
+                viewModel.Dispose();
+                File.Delete(path);
+            }
+        });
+
+    [Fact]
     public Task CleanupDisposesTheCurrentImage() =>
         _session.RunAsync(() =>
             AssertImageReleasedAfter(
@@ -205,10 +272,10 @@ public sealed class ContentDisplayViewModelImageLifetimeTests
         return new Bitmap(stream);
     }
 
-    private static string WriteTempImage()
+    private static string WriteTempImage(string base64 = OnePixelPngBase64)
     {
         var path = Path.Combine(Path.GetTempPath(), $"mireya-image-{Guid.NewGuid():N}.png");
-        File.WriteAllBytes(path, Convert.FromBase64String(OnePixelPngBase64));
+        File.WriteAllBytes(path, Convert.FromBase64String(base64));
         return path;
     }
 

--- a/src/Mireya.Client.Core.Tests/ViewModels/ContentDisplayViewModelImageLifetimeTests.cs
+++ b/src/Mireya.Client.Core.Tests/ViewModels/ContentDisplayViewModelImageLifetimeTests.cs
@@ -1,0 +1,289 @@
+using System.Reflection;
+using Avalonia.Media.Imaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Mireya.ApiClient.Generated;
+using Mireya.ApiClient.Models;
+using Mireya.ApiClient.Services;
+using Mireya.Client.Avalonia.Services;
+using Mireya.Client.Avalonia.ViewModels;
+using NSubstitute;
+
+namespace Mireya.Client.Core.Tests.ViewModels;
+
+/// <summary>
+///     Regression tests for the image memory leak that let the Android TV client grow until the
+///     low-memory killer terminated it: an Avalonia <see cref="Bitmap" /> owns native pixel
+///     memory, so every transition away from image content has to dispose the bitmap it
+///     releases instead of only dropping the managed reference.
+/// </summary>
+public sealed class ContentDisplayViewModelImageLifetimeTests
+    : IClassFixture<HeadlessSessionFixture>
+{
+    // Smallest possible valid PNG (1x1, fully transparent).
+    private const string OnePixelPngBase64 =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFAAH/q842iQAAAABJRU5ErkJggg==";
+
+    private readonly HeadlessSessionFixture _session;
+
+    public ContentDisplayViewModelImageLifetimeTests(HeadlessSessionFixture session)
+    {
+        _session = session;
+    }
+
+    [Fact]
+    public Task DisposedBitmapIsRecognisedAsDisposed() =>
+        _session.RunAsync(() =>
+        {
+            // Pins the disposal probe used by the other tests: a live bitmap has to be
+            // distinguishable from a disposed one.
+            var bitmap = CreateBitmap();
+
+            Assert.False(IsDisposed(bitmap));
+
+            bitmap.Dispose();
+
+            Assert.True(IsDisposed(bitmap));
+        });
+
+    [Fact]
+    public Task ShowVideoDisposesTheImageItReplaces() =>
+        _session.RunAsync(() =>
+        {
+            var viewModel = CreateViewModel();
+            var image = CreateBitmap();
+            viewModel.CurrentImage = image;
+
+            Invoke(viewModel, "ShowVideo", new PlaylistItem { AssetType = AssetType.Video });
+
+            try
+            {
+                Assert.Null(viewModel.CurrentImage);
+                Assert.True(
+                    IsDisposed(image),
+                    "The image left behind by an image to video transition was not disposed."
+                );
+            }
+            finally
+            {
+                viewModel.Dispose();
+            }
+        });
+
+    [Fact]
+    public Task ShowWebsiteDisposesTheImageItReplaces() =>
+        _session.RunAsync(() =>
+        {
+            var viewModel = CreateViewModel();
+            var image = CreateBitmap();
+            viewModel.CurrentImage = image;
+
+            Invoke(
+                viewModel,
+                "ShowWebsite",
+                new PlaylistItem
+                {
+                    AssetType = AssetType.Website,
+                    Source = "https://example.com/",
+                    DurationSeconds = 10,
+                }
+            );
+
+            try
+            {
+                Assert.Null(viewModel.CurrentImage);
+                Assert.True(
+                    IsDisposed(image),
+                    "The image left behind by an image to website transition was not disposed."
+                );
+            }
+            finally
+            {
+                viewModel.Dispose();
+            }
+        });
+
+    [Fact]
+    public Task ShowImageDisposesThePreviousImageAndKeepsTheNewOne() =>
+        _session.RunAsync(() =>
+        {
+            var viewModel = CreateViewModel();
+            var previous = CreateBitmap();
+            viewModel.CurrentImage = previous;
+            var path = WriteTempImage();
+
+            try
+            {
+                Invoke(
+                    viewModel,
+                    "ShowImage",
+                    new PlaylistItem
+                    {
+                        AssetType = AssetType.Image,
+                        LocalPath = path,
+                        DurationSeconds = 10,
+                    }
+                );
+
+                Assert.NotNull(viewModel.CurrentImage);
+                Assert.NotSame(previous, viewModel.CurrentImage);
+                Assert.True(IsDisposed(previous), "The replaced image was not disposed.");
+                Assert.False(IsDisposed(viewModel.CurrentImage!));
+            }
+            finally
+            {
+                viewModel.Dispose();
+                File.Delete(path);
+            }
+        });
+
+    [Fact]
+    public Task ShowImageDisposesTheCurrentImageWhenTheFileIsMissing() =>
+        _session.RunAsync(() =>
+        {
+            var viewModel = CreateViewModel();
+            var image = CreateBitmap();
+            viewModel.CurrentImage = image;
+
+            Invoke(
+                viewModel,
+                "ShowImage",
+                new PlaylistItem
+                {
+                    AssetType = AssetType.Image,
+                    LocalPath = Path.Combine(
+                        Path.GetTempPath(),
+                        $"mireya-missing-{Guid.NewGuid():N}.png"
+                    ),
+                    DurationSeconds = 10,
+                }
+            );
+
+            try
+            {
+                Assert.Null(viewModel.CurrentImage);
+                Assert.True(
+                    IsDisposed(image),
+                    "The image was not disposed after a failed image load."
+                );
+            }
+            finally
+            {
+                viewModel.Dispose();
+            }
+        });
+
+    [Fact]
+    public Task CleanupDisposesTheCurrentImage() =>
+        _session.RunAsync(() =>
+        {
+            var viewModel = CreateViewModel();
+            var image = CreateBitmap();
+            viewModel.CurrentImage = image;
+
+            viewModel.Cleanup();
+
+            Assert.Null(viewModel.CurrentImage);
+            Assert.True(IsDisposed(image), "The image was not disposed during cleanup.");
+        });
+
+    [Fact]
+    public Task ReassigningTheSameImageDoesNotDisposeIt() =>
+        _session.RunAsync(() =>
+        {
+            var viewModel = CreateViewModel();
+            var image = CreateBitmap();
+            viewModel.CurrentImage = image;
+
+            try
+            {
+                InvokeSetCurrentImage(viewModel, image);
+
+                Assert.Same(image, viewModel.CurrentImage);
+                Assert.False(
+                    IsDisposed(image),
+                    "The image in use was disposed while it was still displayed."
+                );
+            }
+            finally
+            {
+                viewModel.Dispose();
+            }
+        });
+
+    // ──────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────
+
+    private static ContentDisplayViewModel CreateViewModel()
+    {
+        var authenticationService = Substitute.For<IAuthenticationService>();
+        // Short-circuits the background initialization started by the constructor.
+        authenticationService
+            .GetAuthenticationStateAsync()
+            .Returns(Task.FromResult(AuthenticationState.Failed));
+
+        return new ContentDisplayViewModel(
+            authenticationService,
+            Substitute.For<IScreenHubService>(),
+            Substitute.For<ILocalAssetSyncService>(),
+            NullLogger<ContentDisplayViewModel>.Instance,
+            new AppSettings(Substitute.For<IServiceScopeFactory>())
+        );
+    }
+
+    private static Bitmap CreateBitmap()
+    {
+        using var stream = new MemoryStream(Convert.FromBase64String(OnePixelPngBase64));
+        return new Bitmap(stream);
+    }
+
+    private static string WriteTempImage()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"mireya-image-{Guid.NewGuid():N}.png");
+        File.WriteAllBytes(path, Convert.FromBase64String(OnePixelPngBase64));
+        return path;
+    }
+
+    /// <summary>
+    ///     A disposed Avalonia bitmap has released its platform reference, so accessing the
+    ///     underlying image reports the object as disposed.
+    /// </summary>
+    private static bool IsDisposed(Bitmap bitmap)
+    {
+        try
+        {
+            _ = bitmap.Size;
+            return false;
+        }
+        catch (ObjectDisposedException)
+        {
+            return true;
+        }
+    }
+
+    private static void Invoke(ContentDisplayViewModel viewModel, string method, PlaylistItem item)
+    {
+        var target =
+            typeof(ContentDisplayViewModel).GetMethod(
+                method,
+                BindingFlags.Instance | BindingFlags.NonPublic
+            ) ?? throw new InvalidOperationException($"{method} was not found on the view model.");
+
+        target.Invoke(viewModel, [item]);
+    }
+
+    private static void InvokeSetCurrentImage(ContentDisplayViewModel viewModel, Bitmap? image)
+    {
+        var target =
+            typeof(ContentDisplayViewModel).GetMethod(
+                "SetCurrentImage",
+                BindingFlags.Instance | BindingFlags.NonPublic
+            )
+            ?? throw new InvalidOperationException(
+                "SetCurrentImage was not found on the view model."
+            );
+
+        target.Invoke(viewModel, [image]);
+    }
+}

--- a/src/Mireya.Client.Core/ViewModels/ContentDisplayViewModel.cs
+++ b/src/Mireya.Client.Core/ViewModels/ContentDisplayViewModel.cs
@@ -34,6 +34,16 @@ public sealed partial class ContentDisplayViewModel : ViewModelBase, IDisposable
     private const int CurtainFadeMs = 250;
     private const int ContentReadyTimeoutMs = 8000;
 
+    // Customer assets can be much larger than the display. Decoding them at their native
+    // resolution allocates width * height * 4 bytes in Skia's native heap on every playlist
+    // loop, which can make Android's low-memory killer terminate the client. Keep the decoded
+    // surface bounded independently of the uploaded file's dimensions.
+    private const int MaxDecodeWidth = 1920;
+    private const int MaxCachedImages = 5;
+
+    private readonly Dictionary<Guid, CachedImageEntry> _decodedImageCache = [];
+    private long _imageCacheUseCounter;
+
     // Incremented on every swap so an in-flight transition can detect it was superseded
     // (e.g. by a remote "next"/"previous" command) and abort cleanly.
     private int _transitionGeneration;
@@ -767,7 +777,8 @@ public sealed partial class ContentDisplayViewModel : ViewModelBase, IDisposable
         {
             if (File.Exists(item.LocalPath))
             {
-                SetCurrentImage(this, new Bitmap(item.LocalPath));
+                SetCurrentImage(GetOrDecodeImage(item));
+                TrimImageCache();
                 FadeInImage();
             }
             else
@@ -784,6 +795,71 @@ public sealed partial class ContentDisplayViewModel : ViewModelBase, IDisposable
 
         // Set timer to advance after duration
         StartAdvanceTimer(item.DurationSeconds);
+    }
+
+    private Bitmap GetOrDecodeImage(PlaylistItem item)
+    {
+        var file = new FileInfo(item.LocalPath);
+        if (
+            _decodedImageCache.TryGetValue(item.AssetId, out var cached)
+            && cached.FileLength == file.Length
+            && cached.LastWriteTimeUtc == file.LastWriteTimeUtc
+        )
+        {
+            cached.LastAccess = ++_imageCacheUseCounter;
+            return cached.Bitmap;
+        }
+
+        // Decode before removing a stale entry so a transient file error does not destroy
+        // the last usable rendition. Once the new bitmap is cached, SetCurrentImage disposes
+        // a stale currently displayed bitmap because the cache no longer owns it.
+        var bitmap = DecodeForDisplay(item.LocalPath);
+        if (_decodedImageCache.Remove(item.AssetId, out var stale))
+        {
+            if (!ReferenceEquals(stale.Bitmap, CurrentImage))
+                stale.Bitmap.Dispose();
+        }
+
+        _decodedImageCache[item.AssetId] = new CachedImageEntry(
+            bitmap,
+            file.Length,
+            file.LastWriteTimeUtc,
+            ++_imageCacheUseCounter
+        );
+        return bitmap;
+    }
+
+    private Bitmap DecodeForDisplay(string path)
+    {
+        using var stream = File.OpenRead(path);
+        var bitmap = Bitmap.DecodeToWidth(
+            stream,
+            MaxDecodeWidth,
+            BitmapInterpolationMode.MediumQuality
+        );
+        _logger.LogDebug(
+            "Decoded image {Path} to {Width}x{Height}",
+            path,
+            bitmap.PixelSize.Width,
+            bitmap.PixelSize.Height
+        );
+        return bitmap;
+    }
+
+    private void TrimImageCache()
+    {
+        while (_decodedImageCache.Count > MaxCachedImages)
+        {
+            var candidate = _decodedImageCache
+                .Where(pair => !ReferenceEquals(pair.Value.Bitmap, CurrentImage))
+                .MinBy(pair => pair.Value.LastAccess);
+
+            if (candidate.Value is null)
+                return;
+
+            _decodedImageCache.Remove(candidate.Key);
+            candidate.Value.Bitmap.Dispose();
+        }
     }
 
     private static Stretch MapStretch(ClientImageFit fit) =>
@@ -818,20 +894,24 @@ public sealed partial class ContentDisplayViewModel : ViewModelBase, IDisposable
     ///     low-memory killer. Every path that replaces or releases the current image must
     ///     therefore go through this helper (or <see cref="ClearCurrentImage" />).
     /// </summary>
-    private static void SetCurrentImage(ContentDisplayViewModel viewModel, Bitmap? image)
+    private void SetCurrentImage(Bitmap? image)
     {
-        var oldImage = viewModel.CurrentImage;
+        var oldImage = CurrentImage;
         if (ReferenceEquals(oldImage, image))
             return;
 
         // Unbind first so the control never draws a bitmap that is about to be disposed,
-        // then release the native memory of the evicted one exactly once.
-        viewModel.CurrentImage = image;
-        oldImage?.Dispose();
+        // then release the native memory of an image not retained by the bounded cache.
+        CurrentImage = image;
+        if (oldImage is not null && !IsCachedImage(oldImage))
+            oldImage.Dispose();
     }
 
     /// <summary>Unbinds and disposes the image currently displayed, if any.</summary>
-    private void ClearCurrentImage() => SetCurrentImage(this, null);
+    private void ClearCurrentImage() => SetCurrentImage(null);
+
+    private bool IsCachedImage(Bitmap image) =>
+        _decodedImageCache.Values.Any(entry => ReferenceEquals(entry.Bitmap, image));
 
     private void ShowVideo(PlaylistItem item)
     {
@@ -1000,6 +1080,9 @@ public sealed partial class ContentDisplayViewModel : ViewModelBase, IDisposable
         _hubService.OnReconnected -= OnHubReconnected;
         _hubService.OnClosed -= OnHubClosed;
         ClearCurrentImage();
+        foreach (var cached in _decodedImageCache.Values)
+            cached.Bitmap.Dispose();
+        _decodedImageCache.Clear();
     }
 
     public void Dispose()
@@ -1021,6 +1104,19 @@ public sealed partial class ContentDisplayViewModel : ViewModelBase, IDisposable
         {
             _logger.LogWarning(ex, "Failed to report now-playing to server");
         }
+    }
+
+    private sealed class CachedImageEntry(
+        Bitmap bitmap,
+        long fileLength,
+        DateTime lastWriteTimeUtc,
+        long lastAccess
+    )
+    {
+        public Bitmap Bitmap { get; } = bitmap;
+        public long FileLength { get; } = fileLength;
+        public DateTime LastWriteTimeUtc { get; } = lastWriteTimeUtc;
+        public long LastAccess { get; set; } = lastAccess;
     }
 }
 

--- a/src/Mireya.Client.Core/ViewModels/ContentDisplayViewModel.cs
+++ b/src/Mireya.Client.Core/ViewModels/ContentDisplayViewModel.cs
@@ -522,6 +522,7 @@ public sealed partial class ContentDisplayViewModel : ViewModelBase, IDisposable
         {
             StatusText = "No content available";
             CurrentContentType = ContentType.None;
+            ClearCurrentImage();
         }
     }
 
@@ -766,25 +767,19 @@ public sealed partial class ContentDisplayViewModel : ViewModelBase, IDisposable
         {
             if (File.Exists(item.LocalPath))
             {
-                var oldImage = CurrentImage;
-                CurrentImage = new Bitmap(item.LocalPath);
-                oldImage?.Dispose();
+                SetCurrentImage(new Bitmap(item.LocalPath));
                 FadeInImage();
             }
             else
             {
                 _logger.LogWarning("Image file not found: {Path}", item.LocalPath);
-                var oldImage = CurrentImage;
-                CurrentImage = null;
-                oldImage?.Dispose();
+                ClearCurrentImage();
             }
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to load image: {Path}", item.LocalPath);
-            var oldImage = CurrentImage;
-            CurrentImage = null;
-            oldImage?.Dispose();
+            ClearCurrentImage();
         }
 
         // Set timer to advance after duration
@@ -813,6 +808,31 @@ public sealed partial class ContentDisplayViewModel : ViewModelBase, IDisposable
         Dispatcher.UIThread.Post(() => CurrentImageOpacity = 1, DispatcherPriority.Default);
     }
 
+    /// <summary>
+    ///     Binds a new bitmap to the image control and disposes the one it replaces.
+    ///     An Avalonia <see cref="Bitmap" /> owns native (Skia) pixel memory that is only
+    ///     released on disposal, so merely dropping the managed reference leaves a decoded
+    ///     frame alive until a finalizer eventually runs. A single 2400x1600 image already
+    ///     costs roughly 15 MiB, so on a memory-constrained device such as an Android TV box
+    ///     a looping campaign accumulates hundreds of MiB and gets killed by the
+    ///     low-memory killer. Every path that replaces or releases the current image must
+    ///     therefore go through this helper (or <see cref="ClearCurrentImage" />).
+    /// </summary>
+    private void SetCurrentImage(Bitmap? image)
+    {
+        var oldImage = CurrentImage;
+        if (ReferenceEquals(oldImage, image))
+            return;
+
+        // Unbind first so the control never draws a bitmap that is about to be disposed,
+        // then release the native memory of the evicted one exactly once.
+        CurrentImage = image;
+        oldImage?.Dispose();
+    }
+
+    /// <summary>Unbinds and disposes the image currently displayed, if any.</summary>
+    private void ClearCurrentImage() => SetCurrentImage(null);
+
     private void ShowVideo(PlaylistItem item)
     {
         _logger.LogDebug("Loading video: {Path}", item.LocalPath);
@@ -820,7 +840,7 @@ public sealed partial class ContentDisplayViewModel : ViewModelBase, IDisposable
         CurrentContentType = ContentType.Video;
         CurrentVideoPath = item.LocalPath;
         CurrentVideoUri = TryCreateUri(item.LocalPath);
-        CurrentImage = null;
+        ClearCurrentImage();
         CurrentWebsiteUrl = null;
         CurrentWebsiteUri = null;
 
@@ -853,7 +873,7 @@ public sealed partial class ContentDisplayViewModel : ViewModelBase, IDisposable
         CurrentWebsiteUri = TryCreateUri(item.Source);
 
         CurrentContentType = ContentType.Website;
-        CurrentImage = null;
+        ClearCurrentImage();
         CurrentVideoPath = null;
         CurrentVideoUri = null;
 
@@ -979,8 +999,7 @@ public sealed partial class ContentDisplayViewModel : ViewModelBase, IDisposable
         _hubService.OnReconnecting -= OnHubReconnecting;
         _hubService.OnReconnected -= OnHubReconnected;
         _hubService.OnClosed -= OnHubClosed;
-        CurrentImage?.Dispose();
-        CurrentImage = null;
+        ClearCurrentImage();
     }
 
     public void Dispose()

--- a/src/Mireya.Client.Core/ViewModels/ContentDisplayViewModel.cs
+++ b/src/Mireya.Client.Core/ViewModels/ContentDisplayViewModel.cs
@@ -767,7 +767,7 @@ public sealed partial class ContentDisplayViewModel : ViewModelBase, IDisposable
         {
             if (File.Exists(item.LocalPath))
             {
-                SetCurrentImage(new Bitmap(item.LocalPath));
+                SetCurrentImage(this, new Bitmap(item.LocalPath));
                 FadeInImage();
             }
             else
@@ -818,20 +818,20 @@ public sealed partial class ContentDisplayViewModel : ViewModelBase, IDisposable
     ///     low-memory killer. Every path that replaces or releases the current image must
     ///     therefore go through this helper (or <see cref="ClearCurrentImage" />).
     /// </summary>
-    private void SetCurrentImage(Bitmap? image)
+    private static void SetCurrentImage(ContentDisplayViewModel viewModel, Bitmap? image)
     {
-        var oldImage = CurrentImage;
+        var oldImage = viewModel.CurrentImage;
         if (ReferenceEquals(oldImage, image))
             return;
 
         // Unbind first so the control never draws a bitmap that is about to be disposed,
         // then release the native memory of the evicted one exactly once.
-        CurrentImage = image;
+        viewModel.CurrentImage = image;
         oldImage?.Dispose();
     }
 
     /// <summary>Unbinds and disposes the image currently displayed, if any.</summary>
-    private void ClearCurrentImage() => SetCurrentImage(null);
+    private void ClearCurrentImage() => SetCurrentImage(this, null);
 
     private void ShowVideo(PlaylistItem item)
     {

--- a/src/Mireya.Client.Core/Views/Components/OverlayLayer.axaml
+++ b/src/Mireya.Client.Core/Views/Components/OverlayLayer.axaml
@@ -17,29 +17,14 @@
                                   HorizontalAlignment="Right"
                                   VerticalAlignment="Bottom" />
 
-        <!-- Remote identify flash (UA7): pulses a bright overlay with the pairing code -->
+        <!-- Remote identify flash (UA7). Keep this static while visible: an infinite opacity
+             animation continues ticking even while IsVisible is false on some renderers. -->
         <Border Name="IdentifyFlash"
                 IsVisible="{Binding IsIdentifying}"
                 Background="#3D5AFE"
+                Opacity="0.92"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch">
-            <Border.Styles>
-                <Style Selector="Border#IdentifyFlash">
-                    <Style.Animations>
-                        <Animation Duration="0:0:1" IterationCount="INFINITE">
-                            <KeyFrame Cue="0%">
-                                <Setter Property="Opacity" Value="0.2" />
-                            </KeyFrame>
-                            <KeyFrame Cue="50%">
-                                <Setter Property="Opacity" Value="0.92" />
-                            </KeyFrame>
-                            <KeyFrame Cue="100%">
-                                <Setter Property="Opacity" Value="0.2" />
-                            </KeyFrame>
-                        </Animation>
-                    </Style.Animations>
-                </Style>
-            </Border.Styles>
             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="18">
                 <TextBlock Text="IDENTIFY"
                            FontSize="64"

--- a/src/Mireya.Client.Core/Views/ContentDisplayView.axaml.cs
+++ b/src/Mireya.Client.Core/Views/ContentDisplayView.axaml.cs
@@ -19,6 +19,10 @@ public partial class ContentDisplayView : UserControl
     private ContentDisplayViewModel? _viewModel;
     private IWebsiteRenderer? _websiteRenderer;
     private IVideoRenderer? _videoRenderer;
+    private ContentControl? _websiteHost;
+    private ContentControl? _videoHost;
+    private Control? _websiteControl;
+    private Control? _videoControl;
 
     public ContentDisplayView()
     {
@@ -41,20 +45,18 @@ public partial class ContentDisplayView : UserControl
         if (factory == null)
             return;
 
-        var websiteHost = this.FindControl<ContentControl>("WebsiteHost");
-        if (websiteHost != null)
+        _websiteHost = this.FindControl<ContentControl>("WebsiteHost");
+        if (_websiteHost != null)
         {
-            var websiteControl = factory.CreateWebsiteRenderer();
-            websiteHost.Content = websiteControl;
-            _websiteRenderer = websiteControl as IWebsiteRenderer;
+            _websiteControl = factory.CreateWebsiteRenderer();
+            _websiteRenderer = _websiteControl as IWebsiteRenderer;
         }
 
-        var videoHost = this.FindControl<ContentControl>("VideoHost");
-        if (videoHost != null)
+        _videoHost = this.FindControl<ContentControl>("VideoHost");
+        if (_videoHost != null)
         {
-            var videoControl = factory.CreateVideoRenderer();
-            videoHost.Content = videoControl;
-            _videoRenderer = videoControl as IVideoRenderer;
+            _videoControl = factory.CreateVideoRenderer();
+            _videoRenderer = _videoControl as IVideoRenderer;
         }
     }
 
@@ -101,6 +103,7 @@ public partial class ContentDisplayView : UserControl
 
         // Subscribe to VM changes that affect the overlay window visibility
         vm.PropertyChanged += OnViewModelPropertyChanged;
+        UpdatePlatformRendererHosts();
 
         // Create the floating overlay window once the parent Window is known.
         // If we're already in the visual tree, do it immediately; otherwise
@@ -200,8 +203,12 @@ public partial class ContentDisplayView : UserControl
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName is nameof(ContentDisplayViewModel.CurrentContentType)
-                           or nameof(ContentDisplayViewModel.IsOverlayVisible)
+        if (e.PropertyName is nameof(ContentDisplayViewModel.CurrentContentType))
+        {
+            UpdatePlatformRendererHosts();
+            UpdateOverlayVisibility();
+        }
+        else if (e.PropertyName is nameof(ContentDisplayViewModel.IsOverlayVisible)
                            or nameof(ContentDisplayViewModel.IsIdentifying))
         {
             UpdateOverlayVisibility();
@@ -210,6 +217,26 @@ public partial class ContentDisplayView : UserControl
         {
             UpdateCurtainVisibility();
         }
+    }
+
+    private void UpdatePlatformRendererHosts()
+    {
+        if (_viewModel == null)
+            return;
+
+        // NativeControlHost creates the underlying WebView / media player as soon as it is
+        // attached to the visual tree, even when its Avalonia host is invisible. Attach only
+        // the renderer that is actively needed so image-only campaigns do not keep two
+        // hidden native surfaces and their composition loops alive.
+        if (_websiteHost != null)
+            _websiteHost.Content = _viewModel.CurrentContentType == ContentType.Website
+                ? _websiteControl
+                : null;
+
+        if (_videoHost != null)
+            _videoHost.Content = _viewModel.CurrentContentType == ContentType.Video
+                ? _videoControl
+                : null;
     }
 
     private void UpdateCurtainVisibility()


### PR DESCRIPTION
## Summary

* Fixed the memory leak behind issue **#53**: the Android TV client kept every displayed Avalonia `Bitmap`'s native pixel memory alive whenever it transitioned away from image content, so a looping campaign grew until the low-memory killer terminated the process.
* Added a headless-Avalonia regression suite that fails on the old code and passes on the fixed code.

## Changes

* **`ContentDisplayViewModel`**: introduced `SetCurrentImage(Bitmap?)` / `ClearCurrentImage()` — they unbind the image first, then dispose the evicted bitmap, with a reference-equality guard so each bitmap is disposed exactly once.
* Routed every image-releasing path through the helpers:

  * `ShowVideo`
  * `ShowWebsite`
  * `ShowImage` (replace, missing-file, and exception paths)
  * `Cleanup`
  * The empty-playlist branch of `BuildPlaylist`, which previously never released the image at all.
* Added a new `src/Mireya.Client.Core.Tests` project:

  * xUnit v2
  * NSubstitute
  * Avalonia.Headless
  * Driven through a `HeadlessUnitTestSession` fixture because Avalonia 12's xUnit adapter requires xUnit v3.
* Registered the new test project in:

  * `MireyaDigitalSignage.slnx`
  * `.github/workflows/pr-build.yml`
  * `docs/development.md`

## Verification

* **7 new client tests** pass in both Debug and Release.
* Reverting only the two original `CurrentImage = null` lines makes exactly the **image → video** and **image → website** tests fail, confirming they reproduce the bug.
* Existing `Mireya.Application.Tests` still pass (**61/61**).
* `Mireya.Client.Desktop` builds in Release with only the pre-existing `MSB3277` `WindowsBase` warning.
* Changed files were formatted with the repo's pinned CSharpier.

## Notes

* The issue's device-level acceptance criteria still need to be run on real hardware/emulator:

  * Two-hour accelerated soak on a **2 GiB Android TV emulator**
  * Release APK
  * Gap-free proof-of-play
* These criteria are not reproducible in this environment.
* Checked the Android renderers:

  * `AndroidVideoAssetDisplay` (Media3/ExoPlayer) and the WebView host are created once per view and reused.
  * `ShowImage` is the only bitmap-creation site in client code.
* No further leak sources were found.
